### PR TITLE
Fix accepted suggestion authors

### DIFF
--- a/extra/tools/help_channel.py
+++ b/extra/tools/help_channel.py
@@ -57,11 +57,11 @@ class HelpChannel(commands.Cog):
                 embed = discord.Embed(
                     title="__Approved Suggestion__",
                     description=message.content,
-                    color=member.color,
+                    color=message.author.color,
                     timestamp=message.created_at
                 )
-                embed.set_thumbnail(url=member.display_avatar)
-                embed.set_footer(text=f"Suggested by: {member}", icon_url=member.display_avatar)
+                embed.set_thumbnail(url=message.author.member.display_avatar)
+                embed.set_footer(text=f"Suggested by: {message.author.nick or message.author}", icon_url=message.author.display_avatar)
                 await channel.send(embed=embed)
             except:
                 pass


### PR DESCRIPTION
Currently all accepted suggestions display the name of the person who accepted the suggestion rather than the person who submitted it. This patch should fix that.